### PR TITLE
B-001 boards page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import TemplatePage from './pages/TemplatePage/templatePage';
 import MainPage from './pages/MainPage/mainPage';
 import AboutPage from './pages/AboutPage/aboutPage';
 import NotFoundPage from './pages/NotFoundPage/notFoundPage';
+import BoardsPage from 'pages/BoardsPage/boardsPage';
 
 import { REACT_APP_BASENAME as BASENAME } from './data/constants';
 
@@ -16,6 +17,7 @@ const App = () => {
         <Route path="/" element={<TemplatePage />}>
           <Route path="/" element={<MainPage />} />
           <Route path="about" element={<AboutPage />} />
+          <Route path="boards" element={<BoardsPage />} />
           <Route path="sign-in" element={<SignIn />} />
           <Route path="sign-up" element={<SignUp />} />
           <Route path="*" element={<NotFoundPage />} />

--- a/src/components/Forms/addBoard.scss
+++ b/src/components/Forms/addBoard.scss
@@ -1,0 +1,3 @@
+.add-board-form {
+  width: 400px;
+}

--- a/src/components/Forms/addBoard.tsx
+++ b/src/components/Forms/addBoard.tsx
@@ -1,19 +1,33 @@
 import Button from '@mui/material/Button';
 import TextField from '@mui/material/TextField';
+import Toast from 'components/Toast/toast';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { BoardParamsType } from 'types';
+import { useAppSelector } from 'redux/hooks';
+import { useCreateBoardMutation } from 'services';
+import { BoardParamsType, ErrorResponse } from 'types';
 
 import './addBoard.scss';
 
-const AddBoard = () => {
+type AddBoardType = {
+  onClose?: () => void;
+};
+
+const AddBoard = ({ onClose }: AddBoardType) => {
   const {
     register,
     handleSubmit,
     formState: { errors },
   } = useForm<BoardParamsType>();
 
+  const [addBoard, { error }] = useCreateBoardMutation();
+  const userId = useAppSelector((state) => state.auth.user.id) as string;
+
   const onSubmit: SubmitHandler<Pick<BoardParamsType, 'title' | 'description'>> = async (data) => {
-    console.log(data);
+    try {
+      await addBoard({ ...data, owner: userId, users: [] }).unwrap();
+    } finally {
+      onClose?.();
+    }
   };
 
   return (
@@ -47,7 +61,10 @@ const AddBoard = () => {
         })}
       />
       {errors.description && <span>{errors.description.message}</span>}
-      <Button variant="contained">Submit</Button>
+      <Button variant="contained" type="submit">
+        Submit
+      </Button>
+      {error && <Toast message={(error as ErrorResponse).data.message} />}
     </form>
   );
 };

--- a/src/components/Forms/addBoard.tsx
+++ b/src/components/Forms/addBoard.tsx
@@ -1,0 +1,55 @@
+import Button from '@mui/material/Button';
+import TextField from '@mui/material/TextField';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { BoardParamsType } from 'types';
+
+import './addBoard.scss';
+
+const AddBoard = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<BoardParamsType>();
+
+  const onSubmit: SubmitHandler<Pick<BoardParamsType, 'title' | 'description'>> = async (data) => {
+    console.log(data);
+  };
+
+  return (
+    <form className="add-board-form" onSubmit={handleSubmit(onSubmit)}>
+      <TextField
+        autoFocus
+        margin="dense"
+        id="title"
+        label="Board title"
+        fullWidth
+        {...register('title', {
+          required: {
+            value: true,
+            message: 'Title cannot be empty',
+          },
+        })}
+      />
+      {errors.title && <span>{errors.title.message}</span>}
+      <TextField
+        margin="dense"
+        id="description"
+        label="Board description"
+        multiline
+        rows={3}
+        fullWidth
+        {...register('description', {
+          required: {
+            value: true,
+            message: 'Description cannot be empty',
+          },
+        })}
+      />
+      {errors.description && <span>{errors.description.message}</span>}
+      <Button variant="contained">Submit</Button>
+    </form>
+  );
+};
+
+export default AddBoard;

--- a/src/components/Forms/addBoard.tsx
+++ b/src/components/Forms/addBoard.tsx
@@ -23,11 +23,8 @@ const AddBoard = ({ onClose }: AddBoardType) => {
   const userId = useAppSelector((state) => state.auth.user.id) as string;
 
   const onSubmit: SubmitHandler<Pick<BoardParamsType, 'title' | 'description'>> = async (data) => {
-    try {
-      await addBoard({ ...data, owner: userId, users: [] }).unwrap();
-    } finally {
-      onClose?.();
-    }
+    await addBoard({ ...data, owner: userId, users: [] }).unwrap();
+    onClose?.();
   };
 
   return (
@@ -62,7 +59,7 @@ const AddBoard = ({ onClose }: AddBoardType) => {
       />
       {errors.description && <span>{errors.description.message}</span>}
       <Button variant="contained" type="submit">
-        Submit
+        Add
       </Button>
       {error && <Toast message={(error as ErrorResponse).data.message} />}
     </form>

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -32,7 +32,14 @@ const Header = () => {
               <li>
                 <Link to="about">about</Link>
               </li>
-              {!isAuthorized && (
+              {isAuthorized ? (
+                <>
+                  <li>+ Add new board</li>
+                  <li>
+                    <Link to="boards">boards</Link>
+                  </li>
+                </>
+              ) : (
                 <>
                   <li>
                     <Link to="sign-in">Sign in</Link>

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -8,6 +8,8 @@ import DeleteOutlineSharpIcon from '@mui/icons-material/DeleteOutlineSharp';
 import ExitToAppIcon from '@mui/icons-material/ExitToApp';
 
 import styles from './header.module.scss';
+import Modal from 'components/Modal/modal';
+import AddBoard from 'components/Forms/addBoard';
 
 const Header = () => {
   const dispatch = useAppDispatch();
@@ -34,7 +36,11 @@ const Header = () => {
               </li>
               {isAuthorized ? (
                 <>
-                  <li>+ Add new board</li>
+                  <li>
+                    <Modal buttonText="+ Add new board" title="Add new board">
+                      <AddBoard />
+                    </Modal>
+                  </li>
                   <li>
                     <Link to="boards">boards</Link>
                   </li>

--- a/src/components/Modal/modal.tsx
+++ b/src/components/Modal/modal.tsx
@@ -6,37 +6,23 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import { IconButton } from '@mui/material';
 import { Close } from '@mui/icons-material';
-import { useDeleteBoardByIdMutation } from 'services';
 
 type ModalPropsType = {
   children: JSX.Element;
   buttonText: string;
   title: string;
   mode?: string;
-  id?: string;
+  onConfirm?: () => Promise<void>;
 };
 
-const Modal = ({ children, buttonText, title, mode, id }: ModalPropsType) => {
+const Modal = ({ children, buttonText, title, mode, onConfirm }: ModalPropsType) => {
   const [open, setOpen] = useState(false);
-  const [deleteBoard] = useDeleteBoardByIdMutation();
 
   const handleClickOpen = () => {
     setOpen(true);
   };
 
   const handleClose = () => {
-    setOpen(false);
-  };
-
-  const handleDelete = async () => {
-    switch (title) {
-      case 'board':
-        await deleteBoard(id as string);
-        break;
-      default:
-        return;
-    }
-
     setOpen(false);
   };
 
@@ -48,7 +34,7 @@ const Modal = ({ children, buttonText, title, mode, id }: ModalPropsType) => {
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>
           {title}
-          {mode !== 'delete' && (
+          {mode !== 'confirm' && (
             <IconButton
               onClick={handleClose}
               sx={{
@@ -72,9 +58,11 @@ const Modal = ({ children, buttonText, title, mode, id }: ModalPropsType) => {
               : null;
           })}
         </DialogContent>
-        {mode === 'delete' && (
+        {mode === 'confirm' && (
           <DialogActions>
-            <Button onClick={handleDelete}>Delete</Button>
+            <Button autoFocus onClick={() => onConfirm?.()}>
+              Delete
+            </Button>
             <Button onClick={handleClose}>Cancel</Button>
           </DialogActions>
         )}

--- a/src/components/Modal/modal.tsx
+++ b/src/components/Modal/modal.tsx
@@ -26,6 +26,11 @@ const Modal = ({ children, buttonText, title, mode, onConfirm }: ModalPropsType)
     setOpen(false);
   };
 
+  const handleConfirm = () => {
+    onConfirm?.();
+    setOpen(false);
+  };
+
   return (
     <>
       <Button onClick={handleClickOpen} variant="outlined" size="small">
@@ -60,7 +65,7 @@ const Modal = ({ children, buttonText, title, mode, onConfirm }: ModalPropsType)
         </DialogContent>
         {mode === 'confirm' && (
           <DialogActions>
-            <Button autoFocus onClick={() => onConfirm?.()}>
+            <Button autoFocus onClick={handleConfirm}>
               Delete
             </Button>
             <Button onClick={handleClose}>Cancel</Button>

--- a/src/components/Modal/modal.tsx
+++ b/src/components/Modal/modal.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
+
+type ModalPropsType = {
+  children: JSX.Element;
+  buttonText: string;
+  title: string;
+  mode?: string;
+};
+
+const Modal = ({ children, buttonText, title, mode }: ModalPropsType) => {
+  const [open, setOpen] = useState(false);
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <Button onClick={handleClickOpen}>{buttonText}</Button>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogContent>{children}</DialogContent>
+        {mode === 'confirm' && (
+          <DialogActions>
+            <Button onClick={handleClose}>Cancel</Button>
+          </DialogActions>
+        )}
+      </Dialog>
+    </>
+  );
+};
+
+export default Modal;

--- a/src/components/Modal/modal.tsx
+++ b/src/components/Modal/modal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Children, cloneElement, isValidElement, ReactNode, useState } from 'react';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -25,10 +25,21 @@ const Modal = ({ children, buttonText, title, mode }: ModalPropsType) => {
 
   return (
     <>
-      <Button onClick={handleClickOpen}>{buttonText}</Button>
+      <Button onClick={handleClickOpen} variant="outlined">
+        {buttonText}
+      </Button>
       <Dialog open={open} onClose={handleClose}>
         <DialogTitle>{title}</DialogTitle>
-        <DialogContent>{children}</DialogContent>
+        <DialogContent>
+          {Children.map<ReactNode, ReactNode>(children, (child) => {
+            return isValidElement(child)
+              ? cloneElement(child, {
+                  ...child.props,
+                  onClose: handleClose,
+                })
+              : null;
+          })}
+        </DialogContent>
         {mode === 'confirm' && (
           <DialogActions>
             <Button onClick={handleClose}>Cancel</Button>

--- a/src/components/Modal/modal.tsx
+++ b/src/components/Modal/modal.tsx
@@ -4,16 +4,21 @@ import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
+import { IconButton } from '@mui/material';
+import { Close } from '@mui/icons-material';
+import { useDeleteBoardByIdMutation } from 'services';
 
 type ModalPropsType = {
   children: JSX.Element;
   buttonText: string;
   title: string;
   mode?: string;
+  id?: string;
 };
 
-const Modal = ({ children, buttonText, title, mode }: ModalPropsType) => {
+const Modal = ({ children, buttonText, title, mode, id }: ModalPropsType) => {
   const [open, setOpen] = useState(false);
+  const [deleteBoard] = useDeleteBoardByIdMutation();
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -23,13 +28,40 @@ const Modal = ({ children, buttonText, title, mode }: ModalPropsType) => {
     setOpen(false);
   };
 
+  const handleDelete = async () => {
+    switch (title) {
+      case 'board':
+        await deleteBoard(id as string);
+        break;
+      default:
+        return;
+    }
+
+    setOpen(false);
+  };
+
   return (
     <>
-      <Button onClick={handleClickOpen} variant="outlined">
+      <Button onClick={handleClickOpen} variant="outlined" size="small">
         {buttonText}
       </Button>
       <Dialog open={open} onClose={handleClose}>
-        <DialogTitle>{title}</DialogTitle>
+        <DialogTitle>
+          {title}
+          {mode !== 'delete' && (
+            <IconButton
+              onClick={handleClose}
+              sx={{
+                position: 'absolute',
+                right: 8,
+                top: 8,
+                color: (theme) => theme.palette.grey[500],
+              }}
+            >
+              <Close />
+            </IconButton>
+          )}
+        </DialogTitle>
         <DialogContent>
           {Children.map<ReactNode, ReactNode>(children, (child) => {
             return isValidElement(child)
@@ -40,8 +72,9 @@ const Modal = ({ children, buttonText, title, mode }: ModalPropsType) => {
               : null;
           })}
         </DialogContent>
-        {mode === 'confirm' && (
+        {mode === 'delete' && (
           <DialogActions>
+            <Button onClick={handleDelete}>Delete</Button>
             <Button onClick={handleClose}>Cancel</Button>
           </DialogActions>
         )}

--- a/src/index.scss
+++ b/src/index.scss
@@ -5,7 +5,6 @@
 }
 
 html {
-  min-height: 100vh;
   height: 100%;
 }
 
@@ -31,6 +30,5 @@ code {
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-height: 100vh;
   height: 100%;
 }

--- a/src/pages/BoardsPage/Board/board.tsx
+++ b/src/pages/BoardsPage/Board/board.tsx
@@ -1,0 +1,29 @@
+import { Card, CardContent, Typography, CardActions, Button } from '@mui/material';
+import Modal from 'components/Modal/modal';
+import { BoardType } from 'types';
+
+const Board = (board: BoardType) => {
+  return (
+    <Card sx={{ width: 240, backgroundColor: '#b4b4b4' }}>
+      <CardContent>
+        <Typography variant="h5">{board.title}</Typography>
+        <Typography>{board.description}</Typography>
+      </CardContent>
+      <CardActions>
+        <Button
+          size="small"
+          variant="contained"
+          sx={{ marginRight: 'auto' }}
+          aria-label="Delete board"
+        >
+          Open
+        </Button>
+        <Modal buttonText="X" title="board" mode="delete" id={board._id}>
+          <p>You want to delete this board. Are you sure?</p>
+        </Modal>
+      </CardActions>
+    </Card>
+  );
+};
+
+export default Board;

--- a/src/pages/BoardsPage/Board/board.tsx
+++ b/src/pages/BoardsPage/Board/board.tsx
@@ -1,8 +1,15 @@
 import { Card, CardContent, Typography, CardActions, Button } from '@mui/material';
 import Modal from 'components/Modal/modal';
 import { BoardType } from 'types';
+import { useDeleteBoardByIdMutation } from 'services';
 
 const Board = (board: BoardType) => {
+  const [deleteBoardById] = useDeleteBoardByIdMutation();
+
+  const handleDelete = async () => {
+    await deleteBoardById(board._id);
+  };
+
   return (
     <Card sx={{ width: 240, backgroundColor: '#b4b4b4' }}>
       <CardContent>
@@ -18,7 +25,7 @@ const Board = (board: BoardType) => {
         >
           Open
         </Button>
-        <Modal buttonText="X" title="board" mode="delete" id={board._id}>
+        <Modal buttonText="X" title="Delete board" mode="confirm" onConfirm={handleDelete}>
           <p>You want to delete this board. Are you sure?</p>
         </Modal>
       </CardActions>

--- a/src/pages/BoardsPage/boardsPage.scss
+++ b/src/pages/BoardsPage/boardsPage.scss
@@ -1,0 +1,7 @@
+.boards-container {
+  display: flex;
+  gap: 20px;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  padding: 20px;
+}

--- a/src/pages/BoardsPage/boardsPage.scss
+++ b/src/pages/BoardsPage/boardsPage.scss
@@ -2,6 +2,6 @@
   display: flex;
   gap: 20px;
   flex-wrap: wrap;
-  align-items: flex-start;
+  align-items: first baseline;
   padding: 20px;
 }

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -7,6 +7,7 @@ import './boardsPage.scss';
 const BoardsPage = () => {
   const userId = useAppSelector((store) => store.auth.user.id) as string;
   const { data } = useGetBoardsSetByUserIdQuery(userId);
+  console.log(data);
 
   return (
     <div className="boards-container">

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -1,0 +1,9 @@
+const BoardsPage = () => {
+  return (
+    <div>
+      <p>Here we can see our boards</p>
+    </div>
+  );
+};
+
+export default BoardsPage;

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -1,7 +1,29 @@
+import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
+import { useAppSelector } from 'redux/hooks';
+import { useGetBoardsSetByUserIdQuery } from 'services';
+
+import './boardsPage.scss';
+
 const BoardsPage = () => {
+  const userId = useAppSelector((store) => store.auth.user.id) as string;
+  const { data } = useGetBoardsSetByUserIdQuery(userId);
+
   return (
-    <div>
-      <p>Here we can see our boards</p>
+    <div className="boards-container">
+      {data &&
+        data.map((board) => (
+          <Card sx={{ width: 240 }} key={board._id}>
+            <CardContent>
+              <Typography variant="h5">{board.title}</Typography>
+              <Typography>{board.description}</Typography>
+            </CardContent>
+            <CardActions>
+              <Button size="small" variant="contained">
+                Learn More
+              </Button>
+            </CardActions>
+          </Card>
+        ))}
     </div>
   );
 };

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -1,9 +1,8 @@
-import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import { useAppSelector } from 'redux/hooks';
 import { useGetBoardsSetByUserIdQuery } from 'services';
 
 import './boardsPage.scss';
-import Modal from 'components/Modal/modal';
+import Board from './Board/board';
 
 const BoardsPage = () => {
   const userId = useAppSelector((store) => store.auth.user.id) as string;
@@ -11,28 +10,7 @@ const BoardsPage = () => {
 
   return (
     <div className="boards-container">
-      {data &&
-        data.map((board) => (
-          <Card sx={{ width: 240, backgroundColor: '#b4b4b4' }} key={board._id}>
-            <CardContent>
-              <Typography variant="h5">{board.title}</Typography>
-              <Typography>{board.description}</Typography>
-            </CardContent>
-            <CardActions>
-              <Button
-                size="small"
-                variant="contained"
-                sx={{ marginRight: 'auto' }}
-                aria-label="Delete board"
-              >
-                Open
-              </Button>
-              <Modal buttonText="X" title="board" mode="delete" id={board._id}>
-                <p>You want to delete this board. Are you sure?</p>
-              </Modal>
-            </CardActions>
-          </Card>
-        ))}
+      {data && data.map((board) => <Board {...board} key={board._id} />)}
     </div>
   );
 };

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -1,27 +1,37 @@
 import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import { useAppSelector } from 'redux/hooks';
 import { useGetBoardsSetByUserIdQuery } from 'services';
+import DeleteForeverOutlinedIcon from '@mui/icons-material/DeleteForeverOutlined';
 
 import './boardsPage.scss';
 
 const BoardsPage = () => {
   const userId = useAppSelector((store) => store.auth.user.id) as string;
   const { data } = useGetBoardsSetByUserIdQuery(userId);
-  console.log(data);
+
+  const handleDeleteClick = (event: React.MouseEvent) => {
+    console.log(event.target);
+  };
 
   return (
     <div className="boards-container">
       {data &&
         data.map((board) => (
-          <Card sx={{ width: 240 }} key={board._id}>
+          <Card sx={{ width: 240, backgroundColor: '#b4b4b4' }} key={board._id}>
             <CardContent>
               <Typography variant="h5">{board.title}</Typography>
               <Typography>{board.description}</Typography>
             </CardContent>
             <CardActions>
               <Button size="small" variant="contained">
-                Learn More
+                Open
               </Button>
+              <DeleteForeverOutlinedIcon
+                id={board._id}
+                onClick={handleDeleteClick}
+                fontSize="large"
+                sx={{ marginLeft: 'auto' }}
+              />
             </CardActions>
           </Card>
         ))}

--- a/src/pages/BoardsPage/boardsPage.tsx
+++ b/src/pages/BoardsPage/boardsPage.tsx
@@ -1,17 +1,13 @@
 import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 import { useAppSelector } from 'redux/hooks';
 import { useGetBoardsSetByUserIdQuery } from 'services';
-import DeleteForeverOutlinedIcon from '@mui/icons-material/DeleteForeverOutlined';
 
 import './boardsPage.scss';
+import Modal from 'components/Modal/modal';
 
 const BoardsPage = () => {
   const userId = useAppSelector((store) => store.auth.user.id) as string;
   const { data } = useGetBoardsSetByUserIdQuery(userId);
-
-  const handleDeleteClick = (event: React.MouseEvent) => {
-    console.log(event.target);
-  };
 
   return (
     <div className="boards-container">
@@ -23,15 +19,17 @@ const BoardsPage = () => {
               <Typography>{board.description}</Typography>
             </CardContent>
             <CardActions>
-              <Button size="small" variant="contained">
+              <Button
+                size="small"
+                variant="contained"
+                sx={{ marginRight: 'auto' }}
+                aria-label="Delete board"
+              >
                 Open
               </Button>
-              <DeleteForeverOutlinedIcon
-                id={board._id}
-                onClick={handleDeleteClick}
-                fontSize="large"
-                sx={{ marginLeft: 'auto' }}
-              />
+              <Modal buttonText="X" title="board" mode="delete" id={board._id}>
+                <p>You want to delete this board. Are you sure?</p>
+              </Modal>
             </CardActions>
           </Card>
         ))}

--- a/src/pages/TemplatePage/templatePage.scss
+++ b/src/pages/TemplatePage/templatePage.scss
@@ -1,9 +1,8 @@
 @import '../../global-styles/variables';
 
 .main-container {
+  flex-grow: 1;
   display: flex;
   max-width: 1200px;
-  width: 100%;
-  height: 100%;
   padding: 0 20px;
 }

--- a/src/services/baseApi.ts
+++ b/src/services/baseApi.ts
@@ -4,6 +4,7 @@ import { BASE_URL, ENDPOINTS } from 'data/constants';
 
 export const baseApiSlice = createApi({
   reducerPath: 'pmaApi',
+  tagTypes: ['Boards'],
   baseQuery: fetchBaseQuery({
     baseUrl: BASE_URL,
     prepareHeaders: (headers, { getState, endpoint }) => {

--- a/src/services/boardsApi.ts
+++ b/src/services/boardsApi.ts
@@ -34,6 +34,7 @@ export const boardsApiSlice = baseApiSlice.injectEndpoints({
         url: `${ENDPOINTS.BOARDS}/${boardId}`,
         method: REQUEST_METHODS.DELETE,
       }),
+      invalidatesTags: ['Boards'],
     }),
     getBoardsSetByIds: build.query<BoardsArrayType, string[]>({
       query: (ids) => ({

--- a/src/services/boardsApi.ts
+++ b/src/services/boardsApi.ts
@@ -6,6 +6,10 @@ export const boardsApiSlice = baseApiSlice.injectEndpoints({
   endpoints: (build) => ({
     getBoards: build.query<BoardsArrayType, void>({
       query: () => ENDPOINTS.BOARDS,
+      providesTags: (result) =>
+        result
+          ? [...result.map(({ _id }) => ({ type: 'Boards' as const, _id })), 'Boards']
+          : ['Boards'],
     }),
     createBoard: build.mutation<BoardType, BoardParamsType>({
       query: (newParams) => ({
@@ -13,6 +17,7 @@ export const boardsApiSlice = baseApiSlice.injectEndpoints({
         method: REQUEST_METHODS.POST,
         body: newParams,
       }),
+      invalidatesTags: ['Boards'],
     }),
     getBoardById: build.query<BoardType, string>({
       query: (boardId) => `${ENDPOINTS.BOARDS}/${boardId}`,
@@ -38,6 +43,10 @@ export const boardsApiSlice = baseApiSlice.injectEndpoints({
     }),
     getBoardsSetByUserId: build.query<BoardsArrayType, string>({
       query: (userId) => `${ENDPOINTS.BOARDSSET}/${userId}`,
+      providesTags: (result) =>
+        result
+          ? [...result.map(({ _id }) => ({ type: 'Boards' as const, _id })), 'Boards']
+          : ['Boards'],
     }),
   }),
 });

--- a/src/types/services/boards.ts
+++ b/src/types/services/boards.ts
@@ -1,6 +1,7 @@
 export type BoardType = {
   _id: string;
   title: string;
+  description: string;
   owner: string;
   users: string[];
 };


### PR DESCRIPTION
1. Button in header with private route to "boards" page.
2. Button in header with private modal to create board.
3. Reusable modal for confirmation and adding (with some improvements we can use it in all app)
![image](https://user-images.githubusercontent.com/81831257/202782294-29bdf991-2f8b-4b64-a80f-ef2588b668fe.png)
4. Form for adding boards (may be reusable for adding columns and tasks in future)
![image](https://user-images.githubusercontent.com/81831257/202782178-f2f8b360-7755-4884-a545-0d5d7280f019.png)
5. Board component with minimal info about board.
6. Add tags for boards to auto-refetch if add and delete boards.